### PR TITLE
Update class-edd-api.php Fix:bug with bbpress profile editing page

### DIFF
--- a/includes/api/class-edd-api.php
+++ b/includes/api/class-edd-api.php
@@ -388,6 +388,8 @@ class EDD_API {
 	public function get_user_public_key( $user_id = 0 ) {
 		global $wpdb;
 
+		require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';
+		
 		if ( empty( $user_id ) ) {
 			return '';
 		}


### PR DESCRIPTION
in the  profile editing page of  bbpress plugin  happened this error :
Fatal error: Call to undefined function edd_has_upgrade_completed() in /home1/linef4me/public_html/wp-content/plugins/easy-digital-downloads/includes/api/class-edd-api.php on line 399
and Solved with add this line
require_once EDD_PLUGIN_DIR . 'includes/admin/upgrades/upgrade-functions.php';